### PR TITLE
Add width column to level/area table

### DIFF
--- a/channel_area/templates/index.html
+++ b/channel_area/templates/index.html
@@ -263,7 +263,7 @@
           <button id="copy-calc-table" class="btn btn-sm btn-secondary ms-2" onclick="copyCalcTable()">Copy Table</button><br>
           <table id="calc-table" class="table table-sm table-striped mt-2">
             <thead>
-              <tr><th>Water Level</th><th>Area</th><th>Width</th></tr>
+              <tr><th>Water Level</th><th>Width</th><th>Area</th></tr>
             </thead>
             <tbody></tbody>
           </table>
@@ -703,7 +703,7 @@
         var maxDepth = Math.max(0, maxH - siltHeightMM);
         var units = document.getElementById('units').value;
         var depthUnits = document.getElementById('height-units').value;
-        thead.innerHTML = '<th>Water Level (' + depthUnits + ')</th><th>Area (' + units + '^2)</th><th>Width (' + depthUnits + ')</th>';
+        thead.innerHTML = '<th>Water Level (' + depthUnits + ')</th><th>Width (' + depthUnits + ')</th><th>Area (' + units + '^2)</th>';
         var unitSq = unitFactor() * unitFactor();
         var mm2perpx2 = mmScale * mmScale;
         var depthDec = decimalsForUnits(depthUnits) + 3;
@@ -719,17 +719,17 @@
           var waterPts = clipBelow(shapePts, yLine);
           var siltPts = clipBelow(shapePts, mmToPxY(siltHeightMM));
           var areaMM2 = (polygonArea(waterPts) - polygonArea(siltPts)) * mm2perpx2;
-          var widthMM = widthAtLine(shapePts, yLine) * mmScale;
+          var widthMM = depthMM > 0 ? widthAtLine(shapePts, yLine) * mmScale : 0;
           var tr = document.createElement('tr');
           var tdL = document.createElement('td');
           tdL.textContent = (depthMM / heightUnitFactor()).toFixed(depthDec);
+          var tdW = document.createElement('td');
+          tdW.textContent = (widthMM / heightUnitFactor()).toFixed(widthDec);
           var tdA = document.createElement('td');
           tdA.textContent = (areaMM2 / unitSq).toFixed(areaDec);
           tr.appendChild(tdL);
-          tr.appendChild(tdA);
-          var tdW = document.createElement('td');
-          tdW.textContent = (widthMM / heightUnitFactor()).toFixed(widthDec);
           tr.appendChild(tdW);
+          tr.appendChild(tdA);
           tbody.appendChild(tr);
           levels.push(depthMM / heightUnitFactor());
           areas.push(areaMM2 / unitSq);

--- a/channel_area/templates/index.html
+++ b/channel_area/templates/index.html
@@ -263,7 +263,7 @@
           <button id="copy-calc-table" class="btn btn-sm btn-secondary ms-2" onclick="copyCalcTable()">Copy Table</button><br>
           <table id="calc-table" class="table table-sm table-striped mt-2">
             <thead>
-              <tr><th>Water Level</th><th>Area</th></tr>
+              <tr><th>Water Level</th><th>Area</th><th>Width</th></tr>
             </thead>
             <tbody></tbody>
           </table>
@@ -703,13 +703,15 @@
         var maxDepth = Math.max(0, maxH - siltHeightMM);
         var units = document.getElementById('units').value;
         var depthUnits = document.getElementById('height-units').value;
-        thead.innerHTML = '<th>Water Level (' + depthUnits + ')</th><th>Area (' + units + '^2)</th>';
+        thead.innerHTML = '<th>Water Level (' + depthUnits + ')</th><th>Area (' + units + '^2)</th><th>Width (' + depthUnits + ')</th>';
         var unitSq = unitFactor() * unitFactor();
         var mm2perpx2 = mmScale * mmScale;
         var depthDec = decimalsForUnits(depthUnits) + 3;
         var areaDec = decimalsForUnits(units) + 3;
+        var widthDec = decimalsForUnits(depthUnits) + 3;
         var levels = [];
         var areas = [];
+        var widths = [];
         for (var i = 0; i < count; i++) {
           var depthMM = maxDepth * i / (count - 1);
           var levelMM = siltHeightMM + depthMM;
@@ -717,6 +719,7 @@
           var waterPts = clipBelow(shapePts, yLine);
           var siltPts = clipBelow(shapePts, mmToPxY(siltHeightMM));
           var areaMM2 = (polygonArea(waterPts) - polygonArea(siltPts)) * mm2perpx2;
+          var widthMM = widthAtLine(shapePts, yLine) * mmScale;
           var tr = document.createElement('tr');
           var tdL = document.createElement('td');
           tdL.textContent = (depthMM / heightUnitFactor()).toFixed(depthDec);
@@ -724,9 +727,13 @@
           tdA.textContent = (areaMM2 / unitSq).toFixed(areaDec);
           tr.appendChild(tdL);
           tr.appendChild(tdA);
+          var tdW = document.createElement('td');
+          tdW.textContent = (widthMM / heightUnitFactor()).toFixed(widthDec);
+          tr.appendChild(tdW);
           tbody.appendChild(tr);
           levels.push(depthMM / heightUnitFactor());
           areas.push(areaMM2 / unitSq);
+          widths.push(widthMM / heightUnitFactor());
         }
         updateCalcChart(levels, areas, depthUnits, units);
       }
@@ -1327,6 +1334,27 @@
           maxY = Math.max(maxY, pts[i].y);
         }
         return {w:(maxX-minX)*mmScale, h:(maxY-minY)*mmScale};
+      }
+
+      function widthAtLine(pts, yLine) {
+        var xs = [];
+        for (var i = 0; i < pts.length; i++) {
+          var a = pts[i];
+          var b = pts[(i + 1) % pts.length];
+          var ay = a.y, by = b.y;
+          if ((ay <= yLine && by >= yLine) || (ay >= yLine && by <= yLine)) {
+            if (ay === by) {
+              xs.push(a.x);
+              xs.push(b.x);
+            } else {
+              var t = (yLine - ay) / (by - ay);
+              xs.push(a.x + t * (b.x - a.x));
+            }
+          }
+        }
+        if (xs.length < 2) return 0;
+        xs.sort(function(p, q){ return p - q; });
+        return xs[xs.length - 1] - xs[0];
       }
 
       function clipBelow(pts, yLine) {


### PR DESCRIPTION
## Summary
- add width column to the lookup table UI
- compute channel width for each level using new `widthAtLine` function

## Testing
- `python -m py_compile channel_area/app.py`

------
https://chatgpt.com/codex/tasks/task_e_686941e0021883299c6f3def8fcdb4e6